### PR TITLE
Fix: Limit `rules`'s prop expression

### DIFF
--- a/text/002-css-rules.md
+++ b/text/002-css-rules.md
@@ -444,7 +444,7 @@ You may also need aliased.
 
 ```typescript
 const myRule = rules({
-  props: ["color", "background", { size: ["padding", "margin"] }]
+  props: ["color", "background", { size: { targets: ["padding", "margin"] }}]
 });
 ```
 
@@ -468,7 +468,7 @@ const myRule = rules({
   props: [
     "color",
     {
-      background: { base: "red" },
+      background: { base: "red", targets: ["background"] },
       size: { base: "3px", targets: ["padding", "margin"] }
     }
   ]


### PR DESCRIPTION
Type inference is difficult because I currently have so many object types.
I have proven that it is possible, but since autocompletion rarely works, we need to change it to as concise a form as possible.
It may be reintroduced in the future through performance improvements and updates to TypeScript.


```typescript
// == Maintained Syntax =======================================================
// 1. Property with Array
rules({
  props: ["color", "background"]
});

// 2. Property with targets
rules({
  props: {
    size: {
      targets: ["padding", "margin"]
    }
  }
});

// == Disappearing Syntax ======================================================
// 1. Property with base value
rules({
  props: {
    background: {
      base: "red"
    }
  }
});

// The targets should bd specified.
rules({
  props: {
    background: {
      base: "red",
      targets: ["background"]
    }
  }
});

// 2. Property with aliased
rules({
  props: {
    size: ["padding", "margin"]
  }
})

// Should be created as an Object structure.
rules({
  props: {
    size: {
      targets: ["padding", "margin"]
    }
  }
});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `rules()` API for dynamic and declarative style definitions.
	- Added support for variants, toggles, and compound variants for conditional styling.
	- Enhanced property grouping with a new `props` feature for better state management.
	- Improved syntax for nested property definitions to enhance clarity.

- **Documentation**
	- Updated documentation with examples demonstrating the use of the new `rules()` API and its features.
	- Ensured backward compatibility with existing styling implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->