### PR TITLE
fix: Using `CSSRuleWith` for CSS Restriction

### DIFF
--- a/text/004-methods.md
+++ b/text/004-methods.md
@@ -120,16 +120,15 @@ const myCss = css.with<{ size: number, radius: number }>(({ size, radius = 0 }) 
 We can also provide type tools like stylex's [`StyleXStyles`](https://stylexjs.com/docs/learn/static-types/#constraining-accepted-styles).
 
 ```typescript
-type AllowProps = CSSRules<{
-  marginTop: 0 | 4 | 8 | 16; // Only allow this values
-}>;
+type RestrictedCSSRule = CSSRuleWith<{
+  // 1. Allowed Props ((required unless marked optional)
+  paddingTop: true; // All value allowed; required
+  marginTop: 0 | 4 | 8 | 16; // Only these values allowed; required
+  paddingBottom?: true; // All value allowed; optional
+  marginBottom?: 0 | 4 | 8 | 16; // Only these values allowed; optional
 
-type ForbiddenProps = CSSRulesWithout<{
-  // Forbidden properties
-  position: false;
-  display: false;
-  top: false;
-  start: false;
+  // 2. Forbidden Props
+  position: false; // Forbidden prop
 }>;
 ```
 


### PR DESCRIPTION
Makes it simpler to constrain CSS properties.
If property is `true`, then make it so that all properties are allowed.

This makes us have the same mental model as [Sprinkles of Vanilla Extract](https://vanilla-extract.style/documentation/packages/sprinkles/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Replaced a dual-type example with a single, explicit rule configuration in the methods docs.
  - Clarifies which properties are allowed, required, optional, or forbidden in the example.
  - Improves readability and streamlines guidance to make the demonstrated API usage clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->